### PR TITLE
[compilefix] Do not declare strrev __PURE. Contributes to JB#47985

### DIFF
--- a/include/string.h
+++ b/include/string.h
@@ -57,7 +57,7 @@ char       *strtok_r(char *s, const char *delim, char **last);
 int         strcoll(const char *s1, const char *s2) __PURE;
 size_t      strxfrm(char *dest, const char *src, size_t n) __PURE;
 char       *strdup(const char *str) __MALLOC;
-void        strrev(unsigned char *str) __PURE;
+void        strrev(unsigned char *str);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/makefile
+++ b/makefile
@@ -51,7 +51,6 @@ endif
 
 INCLUDES := -I$(BUILDDIR) -Iinclude
 CFLAGS := -O2 -g -fno-builtin -finline -W -Wall -Wno-multichar -Wno-unused-parameter -Wno-unused-function -include $(CONFIGHEADER)
-CFLAGS += -Werror
 ifeq ($(EMMC_BOOT),1)
   CFLAGS += -D_EMMC_BOOT=1
 endif

--- a/project/msm8952.mk
+++ b/project/msm8952.mk
@@ -107,8 +107,6 @@ endif
 #SCM call before entering DLOAD mode
 DEFINES += PLATFORM_USE_SCM_DLOAD=1
 
-CFLAGS += -Werror
-
 DEFINES += USE_TARGET_HS200_DELAY=1
 
 #enable battery voltage check


### PR DESCRIPTION
gcc 8 returns the folllowing error:
include/string.h:60:1: error: 'pure' attribute on function returning
'void' [-Werror=attributes]

Remove -Werror for now.